### PR TITLE
Add new feature: storing cropped detected image files to a directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore VSCode configurations
+.vscode
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ The original implementation of Faster-RCNN using Tensorflow can be found [here](
         ```bash
         python main.py -i /path/to/image.jpg -nms-type PY_NMS
         ```
+    - Crop detected images and store them in a folder (start output is an integer to start naming the cropped images, default is 0)
+        ```bash
+        python main.py -i /path/to/image/or/folder -crop-location /path/to/store/cropped/images -start-output 1
+        ```
 
 ## Results
 **Mean AP for this model: 0.9086**

--- a/main.py
+++ b/main.py
@@ -92,6 +92,9 @@ def main():
                         default='model/res101_faster_rcnn_iter_60000.ckpt')
     parser.add_argument('-nms-type', help='Type of nms', choices=['PY_NMS', 'CPU_NMS', 'GPU_NMS'], dest='nms_type',
                         default='CPU_NMS')
+    parser.add_argument('-crop-location', help='The output folder to place the cropped images', dest='crop_output_image_location')
+    parser.add_argument('-start-output', help='Start the numbering of the cropped images filename', dest='start_output_number', 
+                        default=0, type=int)
 
     args = parser.parse_args()
 
@@ -151,12 +154,18 @@ def main():
 
             if args.output is None:
                 cv2.rectangle(img, (int(x1), int(y1)), (int(x2), int(y2)), (0, 0, 255), 2)
+
+            if args.crop_output_image_location:
+                cropped_image = img[int(y1):int(y2), int(x1):int(x2)]
+                cv2.imwrite(args.crop_output_image_location + str(args.start_output_number) + ".jpg", cropped_image)
+                args.start_output_number += 1
+
         if args.output:
             if ((idx+1) % 1000) == 0:
                 # saving the temporary result
                 with open(args.output, 'w') as f:
                     json.dump(result, f)
-        else:
+        elif args.crop_output_image_location is None:
             cv2.imshow(file, img)
 
     if args.output:


### PR DESCRIPTION
Hello!

First of all, thank you for making this wonderful project! I have a pull request that might help to advance this project further.
I have added a new feature to instantly store detected faces in the form of a cropped face to a directory. I have been thinking of several possible use-cases for this new feature:
- If someone wants to gather datasets to train their AI with anime faces, they could easily use this feature to detect faces from their raw images. Saves more time to create datasets!
- If someone wants to get the cropped images, but not in the form of a JSON file. This is of course super helpful for them, as it masks the abstraction and makes this program end-to-end!

Here's the command line I used for this new feature:
```
python main.py -i "D:\Projects\anime-face-detector\saberface.jfif" -nms-type PY_NMS -crop-location ./
```

And the screenshots that I provided should show the results. The images are not mine and All Rights Reserved to their owners / creators / artists.
<img width="887" alt="3" src="https://user-images.githubusercontent.com/31909304/88180910-40870400-cc58-11ea-80f8-3ce216cda2af.png">

<img width="824" alt="2" src="https://user-images.githubusercontent.com/31909304/88180902-3e24aa00-cc58-11ea-86af-7700eebb3191.png">

<img width="769" alt="1" src="https://user-images.githubusercontent.com/31909304/88180888-3bc25000-cc58-11ea-954e-d520fb072cb5.png">

There should be no merge conflicts, I have seen that myself.

Hope you accept my pull request and thank you very much!