### PR TITLE
Add new feature: resize cropped images

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ The original implementation of Faster-RCNN using Tensorflow can be found [here](
         ```bash
         python main.py -i /path/to/image/or/folder -crop-location /path/to/store/cropped/images -start-output 1
         ```
+    - Crop detected images and resizes them
+        ```bash
+        python main.py -i /path/to/image/or/folder -crop-location /path/to/store/cropped/images -crop_height 224 -crop_width 224
+        ```
 
 ## Results
 **Mean AP for this model: 0.9086**

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The original implementation of Faster-RCNN using Tensorflow can be found [here](
         ```
     - Crop detected images and resizes them
         ```bash
-        python main.py -i /path/to/image/or/folder -crop-location /path/to/store/cropped/images -crop_height 224 -crop_width 224
+        python main.py -i /path/to/image/or/folder -crop-location /path/to/store/cropped/images -crop-height 224 -crop-width 224
         ```
 
 ## Results

--- a/main.py
+++ b/main.py
@@ -95,6 +95,8 @@ def main():
     parser.add_argument('-crop-location', help='The output folder to place the cropped images', dest='crop_output_image_location')
     parser.add_argument('-start-output', help='Start the numbering of the cropped images filename', dest='start_output_number', 
                         default=0, type=int)
+    parser.add_argument('-crop-width', help='The width of images to crop', dest='crop_width', type=int)
+    parser.add_argument('-crop-height', help='The height of images to crop', dest='crop_height', type=int)
 
     args = parser.parse_args()
 
@@ -157,6 +159,12 @@ def main():
 
             if args.crop_output_image_location:
                 cropped_image = img[int(y1):int(y2), int(x1):int(x2)]
+
+                if args.crop_width and args.crop_height:
+                    cropped_image = cv2.resize(cropped_image, 
+                                              (args.crop_width, args.crop_height), 
+                                              interpolation = cv2.INTER_AREA)
+
                 cv2.imwrite(args.crop_output_image_location + str(args.start_output_number) + ".jpg", cropped_image)
                 args.start_output_number += 1
 


### PR DESCRIPTION
Hello!

This PR adds two additional arguments to the program (-crop-width and -crop-height) which allows the user to resize the cropped images to their preferred resolution. I added this feature because I have several use-cases in mind:
- Transfer-learning with MobileNet model (TensorFlow 2.0) require images to be 224 x 224 for best performance.
- I think it would be even better to train Deep Learning models if the images are of the same resolution.

Thank you!